### PR TITLE
Enable tap to turn page back and forth via genie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This is a quick hack to support keyboard navigation for remarkable 2 for page flips. I might add more functionality like file or folder navigation later. This is just to show a proof of concept.
+This is a quick hack to support keyboard (or tap) navigation for remarkable 2 for page flips. I might add more functionality like file or folder navigation later. This is just to show a proof of concept.
 
 To use it, you need to have python installed on Remarkable 2, then just run "Python main.py". When it's running you can use left or right arrow key to flip pages. Or you can use 'j' or 'k' key to flip pages.
 
@@ -18,3 +18,34 @@ I need to write some detailed user instructions:
 4. install python by 'opkg install python3'
 
 5. After python installation, you can now run my code using 'python main.py' (need to by python 3.11 or above)
+
+## Enabling Genie and tap to turn page
+
+1. Set up SSH keys so you can SCP files to your remarkable.
+2. Install genie on remarkable:
+   1. `opkg install genie`
+3. Copy files from local over to remarkable via SCP
+
+    ```bash
+    scp ./runner.sh root@remarkable:/home/root/pdfswiper
+    scp ./swipe.py root@remarkable:/home/root/pdfswiper
+    scp ./argreader.py root@remarkable:/home/root/pdfswiper
+    ```
+
+4. Copy or modify your genie config:
+
+    ```bash
+    scp genie.example.conf root@remarkable:/opt/etc/genie.conf
+    ```
+
+    The example genie config makes it so the right 15% will turn the page, then just next to it up to 40% of the way across the screen is another area but this time will turn the page back.
+
+    ```bash
+    nano /opt/etc/genie.conf
+    ```
+
+5. Restart genie on remarkable
+
+    ```bash
+    systemctl restart genie
+    ```

--- a/argreader.py
+++ b/argreader.py
@@ -1,0 +1,4 @@
+import sys
+import swipe
+
+swipe.swipe(sys.argv[1])

--- a/genie.example.conf
+++ b/genie.example.conf
@@ -1,0 +1,9 @@
+gesture=tap
+command=/home/root/pdfswiper/runner.sh right
+zone=0.15 0.8 0.4 1
+fingers=1
+
+gesture=tap
+command=/home/root/pdfswiper/runner.sh left
+zone=0 0.8 0.15 1
+fingers=1

--- a/main.py
+++ b/main.py
@@ -1,168 +1,5 @@
-import struct
-import time
 import curses
-
-# Emit a touch event to the input device using struct
-def emit_event(device, event_type, event_code, event_value):
-    event = struct.pack('llHHi', int(time.time()), int((time.time() % 1) * 1e6), event_type, event_code, event_value)
-    device.write(event)
-    device.flush()
-
-
-# Swipe left function
-def swipe_from_bottom():
-    with open("/dev/input/event2", "wb") as device:
-        try:
-            # Simulate touch down at starting position (right side)
-            emit_event(device, 3, 53, 1500)  # ABS_MT_POSITION_X (X coordinate, starting at the right)
-            emit_event(device, 3, 54, 0)  # ABS_MT_POSITION_Y (Y coordinate, middle of the screen)
-            emit_event(device, 3, 57, 1)     # ABS_MT_TRACKING_ID (New touch ID)
-            emit_event(device, 1, 330, 1)    # BTN_TOUCH (touch down)
-            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # Short delay to simulate the touch action
-            time.sleep(0.05)
-
-            # Simulate movement to the left (swipe)
-            emit_event(device, 3, 54, 300)  # Move to X = 1200
-            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # time.sleep(0.05)
-
-            # emit_event(device, 3, 54, 600)   # Move to X = 900
-            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # time.sleep(0.05)
-
-            # emit_event(device, 3, 54, 900)   # Move to X = 500 (left side of the screen)
-            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # # Short delay before lifting the finger
-            # time.sleep(0.05)
-
-            # Simulate touch up (lift finger)
-            emit_event(device, 1, 330, 0)    # BTN_TOUCH (touch up)
-            emit_event(device, 3, 57, -1)    # ABS_MT_TRACKING_ID (End touch)
-            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-        finally:
-            device.close()    
-
-def swipe_from_top():
-    with open("/dev/input/event2", "wb") as device:
-        try:
-            # Simulate touch down at starting position (right side)
-            emit_event(device, 3, 53, 500)  # ABS_MT_POSITION_X (X coordinate, starting at the right)
-            emit_event(device, 3, 54, 1800)  # ABS_MT_POSITION_Y (Y coordinate, middle of the screen)
-            emit_event(device, 3, 57, 1)     # ABS_MT_TRACKING_ID (New touch ID)
-            emit_event(device, 1, 330, 1)    # BTN_TOUCH (touch down)
-            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # Short delay to simulate the touch action
-            time.sleep(0.05)
-
-            # Simulate movement to the left (swipe)
-            emit_event(device, 3, 54, 1500)  # Move to X = 1200
-            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # time.sleep(0.05)
-
-            # emit_event(device, 3, 54, 1200)   # Move to X = 900
-            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # time.sleep(0.05)
-
-            # emit_event(device, 3, 54, 600)   # Move to X = 500 (left side of the screen)
-            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # Short delay before lifting the finger
-            # time.sleep(0.05)
-
-            # Simulate touch up (lift finger)
-            emit_event(device, 1, 330, 0)    # BTN_TOUCH (touch up)
-            emit_event(device, 3, 57, -1)    # ABS_MT_TRACKING_ID (End touch)
-            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-        finally:
-            device.close()               
-
-# Swipe left function
-def swipe_left():
-    with open("/dev/input/event2", "wb") as device:
-        try:
-            # Simulate touch down at starting position (right side)
-            emit_event(device, 3, 53, 1500)  # ABS_MT_POSITION_X (X coordinate, starting at the right)
-            emit_event(device, 3, 54, 1000)  # ABS_MT_POSITION_Y (Y coordinate, middle of the screen)
-            emit_event(device, 3, 57, 1)     # ABS_MT_TRACKING_ID (New touch ID)
-            emit_event(device, 1, 330, 1)    # BTN_TOUCH (touch down)
-            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # Short delay to simulate the touch action
-            time.sleep(0.05)
-
-            # Simulate movement to the left (swipe)
-            emit_event(device, 3, 53, 1200)  # Move to X = 1200
-            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # time.sleep(0.05)
-
-            # emit_event(device, 3, 53, 900)   # Move to X = 900
-            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # time.sleep(0.05)
-
-            # emit_event(device, 3, 53, 500)   # Move to X = 500 (left side of the screen)
-            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # # Short delay before lifting the finger
-            # time.sleep(0.05)
-
-            # Simulate touch up (lift finger)
-            emit_event(device, 1, 330, 0)    # BTN_TOUCH (touch up)
-            emit_event(device, 3, 57, -1)    # ABS_MT_TRACKING_ID (End touch)
-            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-        finally:
-            device.close()
-
-# Swipe right function
-def swipe_right():
-    with open("/dev/input/event2", "wb") as device:
-        try:
-            # Simulate touch down at starting position (left side)
-            emit_event(device, 3, 53, 500)   # ABS_MT_POSITION_X (X coordinate, starting at the left)
-            emit_event(device, 3, 54, 1000)  # ABS_MT_POSITION_Y (Y coordinate, middle of the screen)
-            emit_event(device, 3, 57, 1)     # ABS_MT_TRACKING_ID (New touch ID)
-            emit_event(device, 1, 330, 1)    # BTN_TOUCH (touch down)
-            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # Short delay to simulate the touch action
-            time.sleep(0.05)
-
-            # Simulate movement to the right (swipe)
-            emit_event(device, 3, 53, 900)   # Move to X = 900
-            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # time.sleep(0.05)
-
-            # emit_event(device, 3, 53, 1200)  # Move to X = 1200
-            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # time.sleep(0.05)
-
-            # emit_event(device, 3, 53, 1500)  # Move to X = 1500 (right side of the screen)
-            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-            # # Short delay before lifting the finger
-            # time.sleep(0.05)
-
-            # Simulate touch up (lift finger)
-            emit_event(device, 1, 330, 0)    # BTN_TOUCH (touch up)
-            emit_event(device, 3, 57, -1)    # ABS_MT_TRACKING_ID (End touch)
-            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
-
-        finally:
-            device.close()
+import key_nav_rm2.swipe as swipe
 
 def on_key_event(event):
     if event.name == 'j':
@@ -181,15 +18,15 @@ def main(stdscr):
         key = stdscr.getch()
 
         if key == ord('j'):
-            swipe_right()
+            swipe.swipe("right")
         if key == ord('k'):
-            swipe_left()
+            swipe.swipe("left")
         if key == curses.KEY_LEFT:
-            swipe_right()
+            swipe.swipe("right")
         if key == curses.KEY_RIGHT:
-            swipe_left()
+            swipe.swipe("left")
         if key == 27:
-            swipe_from_top()
+            swipe.swipe_from_top()
 
         stdscr.refresh()
 

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ def main(stdscr):
         if key == curses.KEY_RIGHT:
             swipe.swipe("left")
         if key == 27:
-            swipe.swipe_from_top()
+            swipe.swipe("top")
 
         stdscr.refresh()
 

--- a/runner.sh
+++ b/runner.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Bash script to run a Python script with an argument
+
+# Check if an argument is provided
+if [ -z "$1" ]; then
+  echo "Usage: $0 {left or right}"
+  exit 1
+fi
+
+# Run the Python script, passing the argument
+python /home/root/pdfswiper/argreader.py "$1"

--- a/swipe.py
+++ b/swipe.py
@@ -1,0 +1,184 @@
+import struct
+import time
+
+BOTTOM = "bottom"
+TOP = "top"
+RIGHT = "right"
+LEFT = "left"
+
+# Emit a touch event to the input device using struct
+def emit_event(device, event_type, event_code, event_value):
+    event = struct.pack('llHHi', int(time.time()), int((time.time() % 1) * 1e6), event_type, event_code, event_value)
+    device.write(event)
+    device.flush()
+
+
+
+def swipe(direction: str) -> None:
+    loweredDirection = direction.lower()
+    if loweredDirection == BOTTOM:
+        return swipe_from_bottom()
+    elif loweredDirection == TOP:
+        return swipe_from_top()
+    elif loweredDirection == RIGHT:
+        return swipe_right()
+    elif loweredDirection == LEFT:
+        return swipe_left()
+    else:
+        print(f"{direction} not supported. Supported directions are: {BOTTOM}, {TOP}, {LEFT}, {RIGHT}.")
+        return
+
+# Swipe left function
+def swipe_from_bottom():
+    with open("/dev/input/event2", "wb") as device:
+        try:
+            # Simulate touch down at starting position (right side)
+            emit_event(device, 3, 53, 1500)  # ABS_MT_POSITION_X (X coordinate, starting at the right)
+            emit_event(device, 3, 54, 0)  # ABS_MT_POSITION_Y (Y coordinate, middle of the screen)
+            emit_event(device, 3, 57, 1)     # ABS_MT_TRACKING_ID (New touch ID)
+            emit_event(device, 1, 330, 1)    # BTN_TOUCH (touch down)
+            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # Short delay to simulate the touch action
+            time.sleep(0.05)
+
+            # Simulate movement to the left (swipe)
+            emit_event(device, 3, 54, 300)  # Move to X = 1200
+            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # time.sleep(0.05)
+
+            # emit_event(device, 3, 54, 600)   # Move to X = 900
+            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # time.sleep(0.05)
+
+            # emit_event(device, 3, 54, 900)   # Move to X = 500 (left side of the screen)
+            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # # Short delay before lifting the finger
+            # time.sleep(0.05)
+
+            # Simulate touch up (lift finger)
+            emit_event(device, 1, 330, 0)    # BTN_TOUCH (touch up)
+            emit_event(device, 3, 57, -1)    # ABS_MT_TRACKING_ID (End touch)
+            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+        finally:
+            device.close()    
+
+def swipe_from_top():
+    with open("/dev/input/event2", "wb") as device:
+        try:
+            # Simulate touch down at starting position (right side)
+            emit_event(device, 3, 53, 500)  # ABS_MT_POSITION_X (X coordinate, starting at the right)
+            emit_event(device, 3, 54, 1800)  # ABS_MT_POSITION_Y (Y coordinate, middle of the screen)
+            emit_event(device, 3, 57, 1)     # ABS_MT_TRACKING_ID (New touch ID)
+            emit_event(device, 1, 330, 1)    # BTN_TOUCH (touch down)
+            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # Short delay to simulate the touch action
+            time.sleep(0.05)
+
+            # Simulate movement to the left (swipe)
+            emit_event(device, 3, 54, 1500)  # Move to X = 1200
+            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # time.sleep(0.05)
+
+            # emit_event(device, 3, 54, 1200)   # Move to X = 900
+            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # time.sleep(0.05)
+
+            # emit_event(device, 3, 54, 600)   # Move to X = 500 (left side of the screen)
+            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # Short delay before lifting the finger
+            # time.sleep(0.05)
+
+            # Simulate touch up (lift finger)
+            emit_event(device, 1, 330, 0)    # BTN_TOUCH (touch up)
+            emit_event(device, 3, 57, -1)    # ABS_MT_TRACKING_ID (End touch)
+            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+        finally:
+            device.close()               
+
+# Swipe left function
+def swipe_left():
+    with open("/dev/input/event2", "wb") as device:
+        try:
+            # Simulate touch down at starting position (right side)
+            emit_event(device, 3, 53, 1500)  # ABS_MT_POSITION_X (X coordinate, starting at the right)
+            emit_event(device, 3, 54, 1000)  # ABS_MT_POSITION_Y (Y coordinate, middle of the screen)
+            emit_event(device, 3, 57, 1)     # ABS_MT_TRACKING_ID (New touch ID)
+            emit_event(device, 1, 330, 1)    # BTN_TOUCH (touch down)
+            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # Short delay to simulate the touch action
+            time.sleep(0.05)
+
+            # Simulate movement to the left (swipe)
+            emit_event(device, 3, 53, 1200)  # Move to X = 1200
+            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # time.sleep(0.05)
+
+            # emit_event(device, 3, 53, 900)   # Move to X = 900
+            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # time.sleep(0.05)
+
+            # emit_event(device, 3, 53, 500)   # Move to X = 500 (left side of the screen)
+            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # # Short delay before lifting the finger
+            # time.sleep(0.05)
+
+            # Simulate touch up (lift finger)
+            emit_event(device, 1, 330, 0)    # BTN_TOUCH (touch up)
+            emit_event(device, 3, 57, -1)    # ABS_MT_TRACKING_ID (End touch)
+            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+        finally:
+            device.close()
+
+# Swipe right function
+def swipe_right():
+    with open("/dev/input/event2", "wb") as device:
+        try:
+            # Simulate touch down at starting position (left side)
+            emit_event(device, 3, 53, 500)   # ABS_MT_POSITION_X (X coordinate, starting at the left)
+            emit_event(device, 3, 54, 1000)  # ABS_MT_POSITION_Y (Y coordinate, middle of the screen)
+            emit_event(device, 3, 57, 1)     # ABS_MT_TRACKING_ID (New touch ID)
+            emit_event(device, 1, 330, 1)    # BTN_TOUCH (touch down)
+            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # Short delay to simulate the touch action
+            time.sleep(0.05)
+
+            # Simulate movement to the right (swipe)
+            emit_event(device, 3, 53, 900)   # Move to X = 900
+            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # time.sleep(0.05)
+
+            # emit_event(device, 3, 53, 1200)  # Move to X = 1200
+            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # time.sleep(0.05)
+
+            # emit_event(device, 3, 53, 1500)  # Move to X = 1500 (right side of the screen)
+            # emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+            # # Short delay before lifting the finger
+            # time.sleep(0.05)
+
+            # Simulate touch up (lift finger)
+            emit_event(device, 1, 330, 0)    # BTN_TOUCH (touch up)
+            emit_event(device, 3, 57, -1)    # ABS_MT_TRACKING_ID (End touch)
+            emit_event(device, 0, 0, 0)      # EV_SYN (sync event)
+
+        finally:
+            device.close()


### PR DESCRIPTION
Hey,

Not sure if you want this feature but I've been annoyed I couldn't easily tap to turn pages on the remarkable 2. I've massaged your repo to let me do just that so I can be lazy with my page navigation. If you want it I think this preserves your existing behaviour.

An annoyance is the example genie config I've suggested does impact when you try to choose a page from the grid view, it'll immediately turn the page but that's easily configurable via Genie if you wish via the `duration`  setting.

Not used Python before so apologies if I've done something silly.